### PR TITLE
Fix search bar overflow alignment and add autocomplete suggestions

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -115,6 +115,18 @@ def related_words():
 
     return jsonify(unique_words)
 
+@app.route('/autocomplete')
+def autocomplete():
+    """!
+    @brief Return word suggestions for the search bar autocomplete.
+    @return JSON response containing a list of word suggestions.
+    """
+    query = request.args.get('q', '').replace(" ", "")
+    if not query:
+        return jsonify([])
+    suggestions = data_access.get_autocomplete_words(query)
+    return jsonify(suggestions)
+
 # This is needed for Vercel to run the app as a serverless function
 def vercel_app(environ, start_response):
     """!

--- a/src/data_access.py
+++ b/src/data_access.py
@@ -288,6 +288,30 @@ class DataAccess:
 
             return words
 
+    def get_autocomplete_words(self, query, limit=10):
+        """!
+        @brief Fetches a list of word suggestions that start with the provided query.
+
+        @param query: The prefix to search for.
+        @param limit: Maximum number of results to return.
+        @return: A list of matching word strings.
+        """
+        if not query:
+            return []
+        with DatabaseConnection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT DISTINCT word
+                FROM korean_words
+                WHERE word LIKE ?
+                ORDER BY word
+                LIMIT ?
+                """,
+                (f"{query}%", limit),
+            )
+            return [row[0] for row in cursor.fetchall()]
+
 
     def find_word_with_unique_hanja(self):
         """!

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -125,14 +125,47 @@ h1 {
   display: flex;
   justify-content: center;
   margin-bottom: 1rem;
+  gap: 10px;
+}
+.search-input-wrapper {
+  position: relative;
+  width: 70%;
+  flex: 1;
+  max-width: 70%;
 }
 .search-bar input {
-  width: 70%;
+  width: 100%;
   padding: 0.5rem;
   font-size: clamp(0.9rem, 1.5vw, 1.5rem);
   border: 1px solid #ccc;
   border-radius: 5px;
-  margin-right: 10px;
+}
+.autocomplete-list {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  list-style: none;
+  padding: 4px 0;
+  margin: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  display: none;
+  z-index: 10;
+}
+.autocomplete-list li {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  margin: 0;
+}
+.autocomplete-list li:hover,
+.autocomplete-list li.active {
+  background-color: #f2f2f2;
 }
 
 /* Remove autofill background color */

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -80,3 +80,114 @@ playButton.addEventListener("click", () => {
     }
 });
 }
+
+document.addEventListener("DOMContentLoaded", () => {
+    const searchInput = document.querySelector('input[data-autocomplete="word"]');
+    const suggestionList = document.querySelector(".autocomplete-list");
+
+    if (!searchInput || !suggestionList) {
+        return;
+    }
+
+    let activeIndex = -1;
+    let debounceTimer = null;
+    let currentController = null;
+
+    const clearSuggestions = () => {
+        suggestionList.innerHTML = "";
+        suggestionList.style.display = "none";
+        activeIndex = -1;
+    };
+
+    const setActiveItem = (index) => {
+        const items = suggestionList.querySelectorAll("li");
+        items.forEach((item, idx) => {
+            item.classList.toggle("active", idx === index);
+        });
+    };
+
+    const applySuggestion = (value) => {
+        searchInput.value = value;
+        clearSuggestions();
+    };
+
+    const fetchSuggestions = async (query) => {
+        if (currentController) {
+            currentController.abort();
+        }
+        currentController = new AbortController();
+
+        try {
+            const response = await fetch(`/autocomplete?q=${encodeURIComponent(query)}`, {
+                signal: currentController.signal,
+            });
+            if (!response.ok) {
+                clearSuggestions();
+                return;
+            }
+            const suggestions = await response.json();
+            if (!Array.isArray(suggestions) || suggestions.length === 0) {
+                clearSuggestions();
+                return;
+            }
+            suggestionList.innerHTML = "";
+            suggestions.forEach((suggestion) => {
+                const item = document.createElement("li");
+                item.textContent = suggestion;
+                item.addEventListener("mousedown", (event) => {
+                    event.preventDefault();
+                    applySuggestion(suggestion);
+                    searchInput.closest("form").submit();
+                });
+                suggestionList.appendChild(item);
+            });
+            suggestionList.style.display = "block";
+        } catch (error) {
+            if (error.name !== "AbortError") {
+                clearSuggestions();
+            }
+        }
+    };
+
+    searchInput.addEventListener("input", (event) => {
+        const query = event.target.value.trim().replace(/\s+/g, "");
+        if (debounceTimer) {
+            clearTimeout(debounceTimer);
+        }
+        if (!query) {
+            clearSuggestions();
+            return;
+        }
+        debounceTimer = setTimeout(() => {
+            fetchSuggestions(query);
+        }, 200);
+    });
+
+    searchInput.addEventListener("keydown", (event) => {
+        const items = suggestionList.querySelectorAll("li");
+        if (items.length === 0) {
+            return;
+        }
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            activeIndex = (activeIndex + 1) % items.length;
+            setActiveItem(activeIndex);
+        } else if (event.key === "ArrowUp") {
+            event.preventDefault();
+            activeIndex = (activeIndex - 1 + items.length) % items.length;
+            setActiveItem(activeIndex);
+        } else if (event.key === "Enter" && activeIndex >= 0) {
+            event.preventDefault();
+            applySuggestion(items[activeIndex].textContent);
+            searchInput.closest("form").submit();
+        } else if (event.key === "Escape") {
+            clearSuggestions();
+        }
+    });
+
+    searchInput.addEventListener("blur", () => {
+        setTimeout(() => {
+            clearSuggestions();
+        }, 150);
+    });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,14 +46,20 @@
             <div class ="search-container">
                 {% if language == 'en' %}
                     <h1>Look Up Hanja for Your Korean Word.</h1>
-                    <form action="/search" method="POST" class="search-bar">
-                        <input type="text" name="word" placeholder="Enter a Korean word" required>
+                    <form action="/search" method="POST" class="search-bar" autocomplete="off">
+                        <div class="search-input-wrapper">
+                            <input type="text" name="word" placeholder="Enter a Korean word" required autocomplete="off" data-autocomplete="word">
+                            <ul class="autocomplete-list" aria-label="Suggestions"></ul>
+                        </div>
                         <button type="submit">Search</button>
                     </form>
                 {% else %}
                     <h1>Trouvez les Hanja associés à un mot coréen:</h1>
-                    <form action="/search" method="POST" class="search-bar">
-                        <input type="text" name="word" placeholder="Entrez un mot en coréen" required>
+                    <form action="/search" method="POST" class="search-bar" autocomplete="off">
+                        <div class="search-input-wrapper">
+                            <input type="text" name="word" placeholder="Entrez un mot en coréen" required autocomplete="off" data-autocomplete="word">
+                            <ul class="autocomplete-list" aria-label="Suggestions"></ul>
+                        </div>
                         <button type="submit">Rechercher</button>
                     </form>
                 {% endif %}


### PR DESCRIPTION
### Motivation
- Prevent the search input from overlapping the search button by constraining layout and adding spacing.
- Improve search usability by providing real-time autocomplete suggestions for Korean words.
- Support keyboard navigation and reliable request handling for a smoother UX.

### Description
- Adjusted CSS by adding `gap` to `.search-bar`, introducing `.search-input-wrapper` with `flex: 1` and `max-width`, and constraining the input to `width: 100%` to prevent overflow and overlap.
- Added styled dropdown rules for the autocomplete with `.autocomplete-list` and item states to position and present suggestions without layout regressions.
- Updated `templates/index.html` to wrap the input inside a `div.search-input-wrapper`, add an `<ul class="autocomplete-list">`, set `autocomplete="off"`, and annotate the input with `data-autocomplete="word"`. 
- Implemented frontend autocomplete logic in `static/js/script.js` that fetches suggestions from `/autocomplete` with debounce and `AbortController`, renders selectable suggestions, and supports arrow keys, Enter, and Escape for navigation and selection. 
- Added backend support with `DataAccess.get_autocomplete_words(query, limit=10)` in `src/data_access.py` and a new Flask route `GET /autocomplete` in `api/app.py` that returns JSON suggestion lists.

### Testing
- Started the development server with `PYTHONPATH=. python api/app.py` which launched successfully and served requests. 
- Ran an automated Playwright script to exercise the search autocomplete flow, but the browser process crashed in this environment so the UI screenshot step failed and no Playwright screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697873b812208323a6e48da2d31945e0)